### PR TITLE
Add firestore service and improve auth flow

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -16,6 +16,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   String _errorMessage = '';
+  bool _loading = false;
 
   @override
   Widget build(BuildContext context) {
@@ -41,10 +42,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
               obscureText: true,
             ),
             const SizedBox(height: 24.0),
-            ElevatedButton(
-              onPressed: _login,
-              child: const Text('Login'),
-            ),
+            if (_loading)
+              const CircularProgressIndicator()
+            else
+              ElevatedButton(
+                onPressed: _login,
+                child: const Text('Login'),
+              ),
             if (_errorMessage.isNotEmpty)
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 12.0),
@@ -70,6 +74,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   }
 
   void _login() async {
+    setState(() { _loading = true; _errorMessage = ''; });
     try {
       final authService = ref.read(authServiceProvider);
       await authService.signInWithEmailAndPassword(
@@ -87,6 +92,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       setState(() {
         _errorMessage = 'An unexpected error occurred.';
       });
+    } finally {
+      if (mounted) setState(() { _loading = false; });
     }
   }
 

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,52 +1,46 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../services/user_service.dart';
-import '../services/auth_service.dart';
-import '../models/user.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../state/firestore_providers.dart';
+import '../state/auth_providers.dart';
 
-class ProfileScreen extends StatelessWidget {
+class ProfileScreen extends ConsumerWidget {
   const ProfileScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final userService = Provider.of<UserService>(context);
-    final authService = Provider.of<AuthService>(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userAsync = ref.watch(userDataProvider);
+    final authService = ref.read(authServiceProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Profile'),
-      ),
-      body: FutureBuilder<User?>(
-        future: userService.getCurrentUser(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasError) {
-            return Center(child: Text('Error: ${snapshot.error}'));
-          }
-          if (!snapshot.hasData || snapshot.data == null) {
+      appBar: AppBar(title: const Text('Profile')),
+      body: userAsync.when(
+        data: (user) {
+          if (user == null) {
             return const Center(child: Text('User not found.'));
           }
-
-          final user = snapshot.data!;
-
           return Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('Email: ${authService.currentUser?.email ?? 'N/A'}', style: const TextStyle(fontSize: 18)),
+                Text('Email: ${authService.currentUser?.email ?? 'N/A'}',
+                    style: const TextStyle(fontSize: 18)),
                 const SizedBox(height: 20),
-                const Text('Placeholder for profile update options...', style: TextStyle(fontSize: 16, fontStyle: FontStyle.italic)),
+                const Text('Placeholder for profile update options...',
+                    style: TextStyle(fontSize: 16, fontStyle: FontStyle.italic)),
                 const Spacer(),
                 ElevatedButton(
-                  onPressed: () async { await authService.signOut(); },
-                  child: const Text('Logout')),
+                  onPressed: () async {
+                    await authService.signOut();
+                  },
+                  child: const Text('Logout'),
+                ),
               ],
             ),
           );
         },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, st) => Center(child: Text('Error: $e')),
       ),
     );
   }

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/user.dart' as app;
+
+class FirestoreService {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+
+  Future<app.User?> getUser(String uid) async {
+    final doc = await _db.collection('users').doc(uid).get();
+    if (doc.exists) {
+      return app.User.fromFirestore(doc);
+    }
+    return null;
+  }
+
+  Stream<app.User?> watchUser(String uid) {
+    return _db.collection('users').doc(uid).snapshots().map((doc) {
+      if (doc.exists) {
+        return app.User.fromFirestore(doc);
+      }
+      return null;
+    });
+  }
+
+  Future<void> createUser(String uid, Map<String, dynamic> data) {
+    return _db.collection('users').doc(uid).set(data);
+  }
+
+  Future<void> updateUser(String uid, Map<String, dynamic> data) {
+    return _db.collection('users').doc(uid).update(data);
+  }
+}

--- a/lib/state/firestore_providers.dart
+++ b/lib/state/firestore_providers.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/firestore_service.dart';
+import 'auth_providers.dart';
+import '../models/user.dart';
+
+final firestoreServiceProvider = Provider<FirestoreService>((ref) {
+  return FirestoreService();
+});
+
+final userDataProvider = StreamProvider<User?>((ref) {
+  final auth = ref.watch(firebaseAuthProvider);
+  final firestore = ref.watch(firestoreServiceProvider);
+  return auth.authStateChanges().asyncExpand((user) {
+    if (user == null) return Stream.value(null);
+    return firestore.watchUser(user.uid);
+  });
+});
+
+final tokenProvider = Provider<int>((ref) {
+  final userData = ref.watch(userDataProvider).value;
+  return userData?.tokenBalance ?? 0;
+});


### PR DESCRIPTION
## Summary
- create `FirestoreService` with helpers to fetch and update user docs
- provide `firestoreServiceProvider`, `userDataProvider` and `tokenProvider`
- enhance sign-up and login screens with loading states and error handling
- create Firestore user doc on sign up
- refactor ProfileScreen to Riverpod and add sign out support

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538736daa0833081abb3d9f9c73ba4