### PR TITLE
Add Firebase authentication and challenge providers

### DIFF
--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,0 +1,53 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class UserModel {
+  final String uid;
+  final String? religion;
+  final String? organizationId;
+  final int tokenCount;
+  final int streak;
+  final String? lastChallengeText;
+  final Timestamp? lastChallenge;
+  final int individualPoints;
+  final Map<String, dynamic> streakMilestones;
+
+  UserModel({
+    required this.uid,
+    this.religion,
+    this.organizationId,
+    required this.tokenCount,
+    required this.streak,
+    this.lastChallengeText,
+    this.lastChallenge,
+    required this.individualPoints,
+    required this.streakMilestones,
+  });
+
+  factory UserModel.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    return UserModel(
+      uid: doc.id,
+      religion: data['religion'],
+      organizationId: data['organizationId'],
+      tokenCount: data['tokenCount'] ?? 0,
+      streak: data['streak'] ?? 0,
+      lastChallengeText: data['lastChallengeText'],
+      lastChallenge: data['lastChallenge'],
+      individualPoints: data['individualPoints'] ?? 0,
+      streakMilestones: Map<String, dynamic>.from(data['streakMilestones'] ?? {}),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'religion': religion,
+      'organizationId': organizationId,
+      'tokenCount': tokenCount,
+      'streak': streak,
+      'lastChallengeText': lastChallengeText,
+      'lastChallenge': lastChallenge,
+      'individualPoints': individualPoints,
+      'streakMilestones': streakMilestones,
+    };
+  }
+}

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -88,10 +88,20 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       setState(() {
         _errorMessage = e.message ?? 'An unknown error occurred.';
       });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(_errorMessage)),
+        );
+      }
     } catch (e) {
       setState(() {
         _errorMessage = 'An unexpected error occurred.';
       });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('An unexpected error occurred.')),
+        );
+      }
     } finally {
       if (mounted) setState(() { _loading = false; });
     }

--- a/lib/screens/auth/signup_screen.dart
+++ b/lib/screens/auth/signup_screen.dart
@@ -38,15 +38,20 @@ class _SignupScreenState extends ConsumerState<SignupScreen> {
         );
         if (user != null) {
           await firestore.createUser(user.uid, {
-            'tokenBalance': 0,
-            'weeklySkipCount': 0,
-            'journalEntries': [],
-            'dailyChallengeStatus': {},
+            'tokenCount': 10,
+            'streak': 0,
+            'individualPoints': 0,
+            'streakMilestones': {},
           });
           if (mounted) context.go('/home');
         }
       } catch (e) {
         setState(() { _error = 'Failed to sign up'; });
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Failed to sign up')),
+          );
+        }
       } finally {
         if (mounted) setState(() { _loading = false; });
       }

--- a/lib/screens/challenge_screen.dart
+++ b/lib/screens/challenge_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../state/challenge_provider.dart'; // Assuming your ChallengeProvider is here
+import '../state/daily_challenge_provider.dart';
+import '../state/firestore_providers.dart';
 
 class ChallengeScreen extends ConsumerWidget {
   const ChallengeScreen({super.key});
@@ -14,22 +15,26 @@ class ChallengeScreen extends ConsumerWidget {
       ),
       body: Consumer(
         builder: (context, WidgetRef ref, _) {
-          final challengeProvider = ref.watch(challengeProviderProvider);
-          final dailyChallenge = challengeProvider.dailyChallenge;
-          final tokenBalance = challengeProvider.tokenCount;
-          final skipCount = challengeProvider.weeklySkipCount;
+          final state = ref.watch(dailyChallengeProvider);
+          final userAsync = ref.watch(userDataProvider);
 
-          if (challengeProvider.isLoading) {
+          if (state.loading || userAsync.isLoading) {
             return const Center(child: CircularProgressIndicator());
           }
 
-          if (dailyChallenge == null) {
-            return const Center(child: Text('Could not load daily challenge.'));
+          final user = userAsync.value;
+          if (user == null) {
+            return const Center(child: Text('User data not found.'));
           }
 
-          final freeSkipsRemaining = skipCount == 0 ? 1 : 0;
-          final nextSkipCost = skipCount > 0 ? (1 << (skipCount - 1)) : 0;
-
+          if (state.challengeText == null) {
+            return Center(
+              child: ElevatedButton(
+                onPressed: () => ref.read(dailyChallengeProvider.notifier).fetchChallenge(),
+                child: const Text('Load Today\'s Challenge'),
+              ),
+            );
+          }
 
           return Padding(
             padding: const EdgeInsets.all(16.0),
@@ -52,7 +57,7 @@ class ChallengeScreen extends ConsumerWidget {
                         ),
                         const SizedBox(height: 8.0),
                         Text(
-                          dailyChallenge.challengeText,
+                          state.challengeText!,
                           style: const TextStyle(fontSize: 16.0),
                         ),
                       ],
@@ -61,88 +66,50 @@ class ChallengeScreen extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16.0),
                 Card(
-                   elevation: 2.0,
-                   child: Padding(
-                     padding: const EdgeInsets.all(16.0),
-                     child: Column(
-                       crossAxisAlignment: CrossAxisAlignment.start,
-                       children: [
-                         Text(
-                           'Tokens: $tokenBalance',
-                           style: const TextStyle(fontSize: 16.0, fontWeight: FontWeight.bold),
-                         ),
-                         const SizedBox(height: 8.0),
-                          Text(
-                           'Free Skips Remaining This Week: $freeSkipsRemaining',
-                            style: const TextStyle(fontSize: 16.0),
-                         ),
-                         if (freeSkipsRemaining == 0)
-                            Text(
-                              'Next Skip Cost: $nextSkipCost tokens',
-                               style: const TextStyle(fontSize: 16.0),
-                            ),
-                       ],
-                     ),
-                   ),
+                  elevation: 2.0,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Tokens: ${user.tokenCount}',
+                          style: const TextStyle(fontSize: 16.0, fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 8.0),
+                        Text('Streak: ${user.streak} days', style: const TextStyle(fontSize: 16.0)),
+                      ],
+                    ),
+                  ),
                 ),
                 const SizedBox(height: 24.0),
-                if (!dailyChallenge.completed && !dailyChallenge.skipped) ...[
-                  ElevatedButton(
-                    onPressed: () async {
-                      await challengeProvider.completeChallenge();
-                      // Show completion feedback
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('Challenge Completed! +3 Tokens'), // Update with actual token amount
-                          backgroundColor: Colors.green,
-                        ),
-                      );
-                    },
-                    child: const Text('Complete'),
-                  ),
-                  const SizedBox(height: 8.0),
-                  ElevatedButton(
-                    onPressed: tokenBalance >= nextSkipCost ? () async {
-                       await challengeProvider.skipChallenge();
-                       // Show skip feedback
-                       String feedbackMessage = freeSkipsRemaining > 0
-                           ? 'Challenge Skipped! Free skip used.'
-                           : 'Challenge Skipped! -$nextSkipCost Tokens';
-                       ScaffoldMessenger.of(context).showSnackBar(
-                         SnackBar(
-                           content: Text(feedbackMessage),
-                           backgroundColor: Colors.orange,
-                         ),
-                       );
-                    } : null, // Disable button if not enough tokens
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.orange,
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () async {
+                          await ref.read(dailyChallengeProvider.notifier).handleComplete();
+                        },
+                        child: const Text('Mark Completed'),
+                      ),
                     ),
-                    child: const Text('Skip'),
-                  ),
-                ] else if (dailyChallenge.completed) ...[
-                   const Center(
-                     child: Text(
-                       'Challenge Completed Today!',
-                       style: TextStyle(fontSize: 18.0, color: Colors.green, fontWeight: FontWeight.bold),
-                       ),
-                   ),
-                ] else if (dailyChallenge.skipped) ...[
-                    const Center(
-                     child: Text(
-                       'Challenge Skipped Today.',
-                       style: TextStyle(fontSize: 18.0, color: Colors.red, fontWeight: FontWeight.bold),
-                       ),
-                   ),
-                ],
-                 const SizedBox(height: 16.0),
-                 TextButton(
-                   onPressed: () {
-                     // TODO: Navigate to Journal Screen
-                     print('Navigate to Journal Screen');
-                   },
-                   child: const Text('View Journal'),
-                 ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () async {
+                          await ref.read(dailyChallengeProvider.notifier).handleSkip();
+                        },
+                        style: ElevatedButton.styleFrom(backgroundColor: Colors.orange),
+                        child: const Text('Skip Challenge'),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16.0),
+                TextButton(
+                  onPressed: () {},
+                  child: const Text('View Journal'),
+                ),
               ],
             ),
           );

--- a/lib/screens/confessional_screen.dart
+++ b/lib/screens/confessional_screen.dart
@@ -7,8 +7,8 @@ class ConfessionalScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final provider = ref.watch(confessionalProvider);
-    final controller = TextEditingController();
+    final state = ref.watch(confessionalProvider);
+    final controller = TextEditingController(text: state.input);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Confessional')),
@@ -16,9 +16,9 @@ class ConfessionalScreen extends ConsumerWidget {
         children: [
           Expanded(
             child: ListView.builder(
-              itemCount: provider.messages.length,
+              itemCount: state.messages.length,
               itemBuilder: (context, index) {
-                final msg = provider.messages[index];
+                final msg = state.messages[index];
                 final isUser = msg['role'] == 'user';
                 return ListTile(
                   title: Align(
@@ -36,7 +36,7 @@ class ConfessionalScreen extends ConsumerWidget {
               },
             ),
           ),
-          if (provider.isLoading) const LinearProgressIndicator(),
+          if (state.loading) const LinearProgressIndicator(),
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: Row(
@@ -53,10 +53,7 @@ class ConfessionalScreen extends ConsumerWidget {
                     final text = controller.text.trim();
                     if (text.isEmpty) return;
                     controller.clear();
-                    await ref.read(confessionalProvider).sendMessage(
-                          text: text,
-                          religion: 'Christian', // placeholder
-                        );
+                    await ref.read(confessionalProvider.notifier).sendMessage(text);
                   },
                 )
               ],

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../services/user_service.dart';
-import '../state/user_provider.dart';
-import '../models/user.dart';
+import '../state/firestore_providers.dart';
+import '../models/user_model.dart';
 import 'journal_screen.dart';
 import 'challenge_screen.dart';
 import 'profile_screen.dart';
@@ -19,26 +18,19 @@ class HomeScreen extends ConsumerStatefulWidget {
 class _HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   Widget build(BuildContext context) {
-    final userService = ref.watch(userServiceProvider);
+    final userAsync = ref.watch(userDataProvider);
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('Home'),
       ),
-      body: StreamBuilder<User?>(
-        stream: userService.streamCurrentUser(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasError) {
-            return Center(child: Text('Error: ${snapshot.error}'));
-          }
-          if (!snapshot.hasData || snapshot.data == null) {
+      body: userAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (UserModel? user) {
+          if (user == null) {
             return const Center(child: Text('User data not found.'));
           }
-
-          final user = snapshot.data!;
 
           return Padding(
             padding: const EdgeInsets.all(16.0),
@@ -47,7 +39,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               children: [
                 Text('Welcome!', style: Theme.of(context).textTheme.headlineMedium),
                 const SizedBox(height: 16),
-                Text('Tokens: ${user.tokenBalance}', style: Theme.of(context).textTheme.titleLarge),
+                Text('Tokens: ${user.tokenCount}', style: Theme.of(context).textTheme.titleLarge),
                 const SizedBox(height: 16),
                 Text('Daily Challenge Status:', style: Theme.of(context).textTheme.titleLarge),
                 // TODO: Display actual challenge status based on user.dailyChallengeStatus
@@ -64,25 +56,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 ),
                  const SizedBox(height: 16),
                 TextButton(
-                  onPressed: () {
-                    // TODO: Add navigation to other screens like Journal, Challenge, Profile, Quote
-                  },
-                const SizedBox(height: 16),
-                Text('Recent Journal Entries:', style: Theme.of(context).textTheme.titleLarge),
-                // TODO: Display recent journal entries
-                Expanded(
-                  child: ListView.builder(
-                    itemCount: user.journalEntries.length,
-                    itemBuilder: (context, index) {
-                      final entry = user.journalEntries[index];
-                      // TODO: Format journal entry display
-                      return ListTile(
-                        title: Text(entry['entry'] ?? 'No entry text'),
-                        subtitle: Text(entry['timestamp']?.toString() ?? 'No timestamp'),
-                      );
-                    },
-                  ),
+                  onPressed: () {},
+                  child: const Text('More Features Coming Soon'),
                 ),
+                const SizedBox(height: 16),
+                const Text('Recent Journal Entries feature coming soon'),
               ],
             ),
           );

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,13 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../state/auth_providers.dart';
+import 'package:go_router/go_router.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.read(authServiceProvider);
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: const Center(child: Text('Settings Screen')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () async {
+            await auth.signOut();
+            if (context.mounted) context.go('/login');
+          },
+          child: const Text('Sign Out'),
+        ),
+      ),
     );
   }
 }

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -1,21 +1,21 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import '../models/user.dart' as app;
+import '../models/user_model.dart';
 
 class FirestoreService {
   final FirebaseFirestore _db = FirebaseFirestore.instance;
 
-  Future<app.User?> getUser(String uid) async {
+  Future<UserModel?> getUser(String uid) async {
     final doc = await _db.collection('users').doc(uid).get();
     if (doc.exists) {
-      return app.User.fromFirestore(doc);
+      return UserModel.fromFirestore(doc);
     }
     return null;
   }
 
-  Stream<app.User?> watchUser(String uid) {
+  Stream<UserModel?> watchUser(String uid) {
     return _db.collection('users').doc(uid).snapshots().map((doc) {
       if (doc.exists) {
-        return app.User.fromFirestore(doc);
+        return UserModel.fromFirestore(doc);
       }
       return null;
     });
@@ -27,5 +27,19 @@ class FirestoreService {
 
   Future<void> updateUser(String uid, Map<String, dynamic> data) {
     return _db.collection('users').doc(uid).update(data);
+  }
+
+  Future<void> incrementReligionPoints(String religionId, int points) {
+    return _db
+        .collection('religions')
+        .doc(religionId)
+        .update({'totalPoints': FieldValue.increment(points)});
+  }
+
+  Future<void> incrementOrganizationPoints(String organizationId, int points) {
+    return _db
+        .collection('organizations')
+        .doc(organizationId)
+        .update({'totalPoints': FieldValue.increment(points)});
   }
 }

--- a/lib/state/daily_challenge_provider.dart
+++ b/lib/state/daily_challenge_provider.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../services/firestore_service.dart';
+import '../services/functions_service.dart';
+import 'auth_providers.dart';
+import 'firestore_providers.dart';
+import '../models/user_model.dart';
+
+class DailyChallengeState {
+  final bool loading;
+  final String? challengeText;
+  final String? error;
+
+  const DailyChallengeState({this.loading = false, this.challengeText, this.error});
+
+  DailyChallengeState copyWith({bool? loading, String? challengeText, String? error}) {
+    return DailyChallengeState(
+      loading: loading ?? this.loading,
+      challengeText: challengeText ?? this.challengeText,
+      error: error,
+    );
+  }
+}
+
+class DailyChallengeNotifier extends StateNotifier<DailyChallengeState> {
+  DailyChallengeNotifier(this.ref) : super(const DailyChallengeState());
+
+  final Ref ref;
+
+  Future<UserModel?> _currentUser() async {
+    final auth = ref.read(firebaseAuthProvider);
+    final user = auth.currentUser;
+    if (user == null) return null;
+    return await ref.read(firestoreServiceProvider).getUser(user.uid);
+  }
+
+  Future<void> fetchChallenge() async {
+    final userData = await _currentUser();
+    if (userData == null) return;
+
+    final last = userData.lastChallenge?.toDate();
+    if (last != null && DateTime.now().difference(last).inHours < 24 && userData.lastChallengeText != null) {
+      state = state.copyWith(challengeText: userData.lastChallengeText);
+      return;
+    }
+
+    state = state.copyWith(loading: true, error: null);
+    try {
+      final functions = ref.read(functionsServiceProvider);
+      final challenge = await functions.getDailyChallenge(religion: userData.religion ?? 'spiritual');
+      await ref.read(firestoreServiceProvider).updateUser(userData.uid, {
+        'lastChallenge': Timestamp.now(),
+        'lastChallengeText': challenge,
+      });
+      state = DailyChallengeState(challengeText: challenge);
+    } catch (e) {
+      state = state.copyWith(error: e.toString());
+    } finally {
+      state = state.copyWith(loading: false);
+    }
+  }
+
+  Future<void> handleSkip() async {
+    final userData = await _currentUser();
+    if (userData == null) return;
+    if (userData.tokenCount < 3) {
+      state = state.copyWith(error: 'Not enough tokens');
+      return;
+    }
+    await ref.read(firestoreServiceProvider)
+        .updateUser(userData.uid, {'tokenCount': userData.tokenCount - 3});
+    await fetchChallenge();
+  }
+
+  Future<void> handleComplete() async {
+    final userData = await _currentUser();
+    if (userData == null) return;
+    final firestore = ref.read(firestoreServiceProvider);
+    final functions = ref.read(functionsServiceProvider);
+    final newStreak = userData.streak + 1;
+    await firestore.updateUser(userData.uid, {
+      'streak': newStreak,
+      'tokenCount': userData.tokenCount + 1,
+      'individualPoints': userData.individualPoints + 5,
+    });
+
+    if ([3,7,14,30].contains(newStreak) && !(userData.streakMilestones['$newStreak'] == true)) {
+      await firestore.updateUser(userData.uid, {'streakMilestones.$newStreak': true});
+      await functions.getMilestoneBlessing(religion: userData.religion ?? 'spiritual', streak: newStreak);
+    }
+
+    if (userData.religion != null) {
+      await firestore.incrementReligionPoints(userData.religion!, 5);
+    }
+    if (userData.organizationId != null) {
+      await firestore.incrementOrganizationPoints(userData.organizationId!, 5);
+    }
+
+    state = state.copyWith();
+  }
+}
+
+final dailyChallengeProvider =
+    StateNotifierProvider<DailyChallengeNotifier, DailyChallengeState>((ref) {
+  return DailyChallengeNotifier(ref);
+});

--- a/lib/state/firestore_providers.dart
+++ b/lib/state/firestore_providers.dart
@@ -1,13 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/firestore_service.dart';
 import 'auth_providers.dart';
-import '../models/user.dart';
+import '../models/user_model.dart';
 
 final firestoreServiceProvider = Provider<FirestoreService>((ref) {
   return FirestoreService();
 });
 
-final userDataProvider = StreamProvider<User?>((ref) {
+final userDataProvider = StreamProvider<UserModel?>((ref) {
   final auth = ref.watch(firebaseAuthProvider);
   final firestore = ref.watch(firestoreServiceProvider);
   return auth.authStateChanges().asyncExpand((user) {
@@ -18,5 +18,5 @@ final userDataProvider = StreamProvider<User?>((ref) {
 
 final tokenProvider = Provider<int>((ref) {
   final userData = ref.watch(userDataProvider).value;
-  return userData?.tokenBalance ?? 0;
+  return userData?.tokenCount ?? 0;
 });


### PR DESCRIPTION
## Summary
- implement Firebase login and signup flows
- store user data in Firestore using new `UserModel`
- add sign out button in `SettingsScreen`
- provide stream of user data via `userDataProvider`
- implement daily challenge logic with `DailyChallengeNotifier`
- update challenge and confessional features to use Cloud Functions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538963158c83309bcfeccfdd348444