### PR TITLE
Add Cloud Function REST integration for daily challenge and confessional

### DIFF
--- a/lib/screens/challenge_screen.dart
+++ b/lib/screens/challenge_screen.dart
@@ -36,6 +36,16 @@ class ChallengeScreen extends ConsumerWidget {
             );
           }
 
+          if (state.error != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text(state.error!)),
+              );
+              ref.read(dailyChallengeProvider.notifier)
+                  .state = state.copyWith(error: null);
+            });
+          }
+
           return Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
@@ -87,18 +97,26 @@ class ChallengeScreen extends ConsumerWidget {
                   children: [
                     Expanded(
                       child: ElevatedButton(
-                        onPressed: () async {
-                          await ref.read(dailyChallengeProvider.notifier).handleComplete();
-                        },
+                        onPressed: state.loading
+                            ? null
+                            : () async {
+                                await ref
+                                    .read(dailyChallengeProvider.notifier)
+                                    .handleComplete();
+                              },
                         child: const Text('Mark Completed'),
                       ),
                     ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: ElevatedButton(
-                        onPressed: () async {
-                          await ref.read(dailyChallengeProvider.notifier).handleSkip();
-                        },
+                        onPressed: state.loading || user.tokenCount < 3
+                            ? null
+                            : () async {
+                                await ref
+                                    .read(dailyChallengeProvider.notifier)
+                                    .handleSkip();
+                              },
                         style: ElevatedButton.styleFrom(backgroundColor: Colors.orange),
                         child: const Text('Skip Challenge'),
                       ),

--- a/lib/services/http_service.dart
+++ b/lib/services/http_service.dart
@@ -1,16 +1,12 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:firebase_auth/firebase_auth.dart';
-
 class HttpService {
   final String baseUrl;
+
   HttpService({required this.baseUrl});
 
   Future<http.Response> post(String path, Map<String, dynamic> body,
-      {Map<String, String>? headers}) async {
-    final user = FirebaseAuth.instance.currentUser;
-    final idToken = await user?.getIdToken();
-
+      {String? idToken, Map<String, String>? headers}) async {
     final requestHeaders = <String, String>{
       'Content-Type': 'application/json',
       if (headers != null) ...headers,


### PR DESCRIPTION
## Summary
- implement optional auth token in `HttpService.post`
- fetch daily challenge and milestone blessings through REST with auth token
- update skip and complete logic with token checks
- build REST-based confessional messaging with conversation history and token deduction
- improve challenge and confessional screens with error handling and button states

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*

------
https://chatgpt.com/codex/tasks/task_e_6853905782a08330b20267e5112b7a98