### PR TITLE
Implement ReligionAI & Trivia with robust error handling

### DIFF
--- a/lib/screens/trivia_screen.dart
+++ b/lib/screens/trivia_screen.dart
@@ -1,13 +1,84 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../state/trivia_provider.dart';
 
-class TriviaScreen extends StatelessWidget {
+class TriviaScreen extends ConsumerStatefulWidget {
   const TriviaScreen({super.key});
 
   @override
+  ConsumerState<TriviaScreen> createState() => _TriviaScreenState();
+}
+
+class _TriviaScreenState extends ConsumerState<TriviaScreen> {
+  final TextEditingController _religionController = TextEditingController();
+  final TextEditingController _storyController = TextEditingController();
+
+  @override
+  void dispose() {
+    _religionController.dispose();
+    _storyController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final state = ref.watch(triviaProvider);
+    final notifier = ref.read(triviaProvider.notifier);
+
     return Scaffold(
       appBar: AppBar(title: const Text('Trivia')),
-      body: const Center(child: Text('Trivia Screen')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ElevatedButton(
+              onPressed: state.loading ? null : notifier.fetchTriviaQuestion,
+              child: const Text('Get Question'),
+            ),
+            const SizedBox(height: 12),
+            if (state.story != null)
+              Text(state.story!),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _religionController,
+              decoration: const InputDecoration(
+                labelText: 'Religion Guess',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _storyController,
+              decoration: const InputDecoration(
+                labelText: 'Story Guess',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: state.loading || state.storyId == null
+                  ? null
+                  : () => notifier.submitGuess(
+                        _religionController.text,
+                        _storyController.text,
+                      ),
+              child: state.loading
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Submit Guess'),
+            ),
+            const SizedBox(height: 12),
+            if (state.error != null)
+              Text(state.error!, style: const TextStyle(color: Colors.red)),
+            if (state.resultText != null)
+              Text(state.resultText!),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/services/http_service.dart
+++ b/lib/services/http_service.dart
@@ -1,12 +1,39 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+
 import 'package:http/http.dart' as http;
+
+/// Exception thrown when a HTTP call fails.
+class HttpServiceException implements Exception {
+  /// Human readable message to present to the user.
+  final String message;
+
+  /// Optional status code returned by the server.
+  final int? statusCode;
+
+  HttpServiceException(this.message, [this.statusCode]);
+
+  @override
+  String toString() =>
+      statusCode != null ? '$statusCode: $message' : 'HttpServiceException: $message';
+}
+
 class HttpService {
   final String baseUrl;
 
   HttpService({required this.baseUrl});
 
-  Future<http.Response> post(String path, Map<String, dynamic> body,
-      {String? idToken, Map<String, String>? headers}) async {
+  /// Sends a POST request and returns the decoded JSON body on success.
+  ///
+  /// Throws [HttpServiceException] for any error, including non-200 responses
+  /// and network issues.
+  Future<Map<String, dynamic>> post(
+    String path,
+    Map<String, dynamic> body, {
+    String? idToken,
+    Map<String, String>? headers,
+  }) async {
     final requestHeaders = <String, String>{
       'Content-Type': 'application/json',
       if (headers != null) ...headers,
@@ -14,6 +41,33 @@ class HttpService {
     };
 
     final uri = Uri.parse('$baseUrl/$path');
-    return http.post(uri, headers: requestHeaders, body: jsonEncode(body));
+    try {
+      final response = await http
+          .post(uri, headers: requestHeaders, body: jsonEncode(body))
+          .timeout(const Duration(seconds: 10));
+
+      final status = response.statusCode;
+      final bodyStr = response.body.isNotEmpty ? response.body : '{}';
+
+      final data = jsonDecode(bodyStr) as Map<String, dynamic>;
+
+      if (status >= 200 && status < 300) {
+        return data;
+      }
+
+      final errorMsg = data['error']?.toString() ??
+          response.reasonPhrase ??
+          'Request failed';
+      throw HttpServiceException(errorMsg, status);
+    } on SocketException {
+      throw HttpServiceException('Network error. Please check your connection.');
+    } on TimeoutException {
+      throw HttpServiceException('Connection timed out.');
+    } on FormatException {
+      throw HttpServiceException('Invalid response format.');
+    } catch (e) {
+      if (e is HttpServiceException) rethrow;
+      throw HttpServiceException(e.toString());
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add HttpServiceException and improved HTTP error handling
- integrate ReligionAI provider and UI with user question state
- implement Trivia provider interactions and UI
- surface errors in Daily Challenge and Confessional providers

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539276503c833092d30ba2ee48afe3