### PR TITLE
Improve HTTP service and profile UI

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -25,9 +25,11 @@ class ProfileScreen extends ConsumerWidget {
               children: [
                 Text('Email: ${authService.currentUser?.email ?? 'N/A'}',
                     style: const TextStyle(fontSize: 18)),
-                const SizedBox(height: 20),
-                const Text('Placeholder for profile update options...',
-                    style: TextStyle(fontSize: 16, fontStyle: FontStyle.italic)),
+                const SizedBox(height: 12),
+                Text('Religion: ${user.religion ?? 'None'}'),
+                Text('Tokens: ${user.tokenCount}'),
+                Text('Streak: ${user.streak} days'),
+                Text('Points: ${user.individualPoints}'),
                 const Spacer(),
                 ElevatedButton(
                   onPressed: () async {

--- a/lib/services/http_service.dart
+++ b/lib/services/http_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
+import 'package:firebase_auth/firebase_auth.dart';
 
 /// Exception thrown when a HTTP call fails.
 class HttpServiceException implements Exception {
@@ -34,6 +35,8 @@ class HttpService {
     String? idToken,
     Map<String, String>? headers,
   }) async {
+    idToken ??= await FirebaseAuth.instance.currentUser?.getIdToken();
+
     final requestHeaders = <String, String>{
       'Content-Type': 'application/json',
       if (headers != null) ...headers,
@@ -56,6 +59,8 @@ class HttpService {
       }
 
       final errorMsg = data['error']?.toString() ??
+          data['message']?.toString() ??
+          (data['error'] is Map ? data['error']['message']?.toString() : null) ??
           response.reasonPhrase ??
           'Request failed';
       throw HttpServiceException(errorMsg, status);


### PR DESCRIPTION
## Summary
- enhance HttpService to auto-attach Firebase ID tokens and parse more error fields
- expand ProfileScreen with user data such as religion, tokens, streak, and points

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68539462184c83309459a7f823b7183d