### PR TITLE
Switch to Firebase REST API

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'dart:async';
 
 import 'screens/auth/login_screen.dart';
@@ -76,7 +75,6 @@ final routerProvider = Provider<GoRouter>((ref) {
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(); // Initialize Firebase
 
   runApp(
     const ProviderScope(

--- a/lib/models/daily_challenge.dart
+++ b/lib/models/daily_challenge.dart
@@ -1,11 +1,9 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-
 class DailyChallenge {
   final String challengeText;
   final bool completed;
   final bool skipped;
-  final Timestamp timestampAssigned;
-  final Timestamp? timestampCompleted;
+  final DateTime timestampAssigned;
+  final DateTime? timestampCompleted;
   final int skipCost;
 
   DailyChallenge({
@@ -17,20 +15,19 @@ class DailyChallenge {
     required this.skipCost,
   });
 
-  // Factory constructor to create a DailyChallenge from a Firestore document
-  factory DailyChallenge.fromDocument(DocumentSnapshot doc) {
+  factory DailyChallenge.fromMap(Map<String, dynamic> data) {
     return DailyChallenge(
-      challengeText: doc['challengeText'] ?? '',
-      completed: doc['completed'] ?? false,
-      skipped: doc['skipped'] ?? false,
-      timestampAssigned: doc['timestampAssigned'] ?? Timestamp.now(),
-      timestampCompleted: doc['timestampCompleted'],
-      skipCost: doc['skipCost'] ?? 0,
+      challengeText: data['challengeText'] as String? ?? '',
+      completed: data['completed'] as bool? ?? false,
+      skipped: data['skipped'] as bool? ?? false,
+      timestampAssigned:
+          data['timestampAssigned'] as DateTime? ?? DateTime.now(),
+      timestampCompleted: data['timestampCompleted'] as DateTime?,
+      skipCost: data['skipCost'] as int? ?? 0,
     );
   }
 
-  // Method to convert a DailyChallenge to a Firestore document
-  Map<String, dynamic> toDocument() {
+  Map<String, dynamic> toMap() {
     return {
       'challengeText': challengeText,
       'completed': completed,

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,12 +1,10 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-
 class User {
   final String uid;
   final List<Map<String, dynamic>> journalEntries;
   final int tokenBalance;
-  final Map<String, dynamic> dailyChallengeStatus; // This might be redundant with the new dailyChallenges subcollection, consider removing or refactoring
+  final Map<String, dynamic> dailyChallengeStatus;
   final int weeklySkipCount;
-  final Timestamp? lastSkipReset;
+  final DateTime? lastSkipReset;
 
   User({
     required this.uid,
@@ -17,18 +15,18 @@ class User {
     this.lastSkipReset,
   });
 
-  factory User.fromFirestore(DocumentSnapshot doc) {
-    Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+  factory User.fromMap(Map<String, dynamic> data, String uid) {
     return User(
-      uid: doc.id,
+      uid: uid,
       journalEntries: (data['journalEntries'] as List<dynamic>?)
-              ?.map((e) => e as Map<String, dynamic>)
+              ?.map((e) => Map<String, dynamic>.from(e as Map))
               .toList() ??
           [],
-      tokenBalance: data['tokenBalance'] ?? 0,
-      dailyChallengeStatus: data['dailyChallengeStatus'] as Map<String, dynamic>? ?? {}, // Consider refactoring this
-      weeklySkipCount: data['weeklySkipCount'] ?? 0,
-      lastSkipReset: data['lastSkipReset'] as Timestamp?,
+      tokenBalance: data['tokenBalance'] as int? ?? 0,
+      dailyChallengeStatus:
+          Map<String, dynamic>.from(data['dailyChallengeStatus'] as Map? ?? {}),
+      weeklySkipCount: data['weeklySkipCount'] as int? ?? 0,
+      lastSkipReset: data['lastSkipReset'] as DateTime?,
     );
   }
 
@@ -36,7 +34,7 @@ class User {
     return {
       'journalEntries': journalEntries,
       'tokenBalance': tokenBalance,
-      'dailyChallengeStatus': dailyChallengeStatus, // Consider refactoring this
+      'dailyChallengeStatus': dailyChallengeStatus,
       'weeklySkipCount': weeklySkipCount,
       'lastSkipReset': lastSkipReset,
     };

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,5 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-
 class UserModel {
   final String uid;
   final String? religion;
@@ -7,7 +5,7 @@ class UserModel {
   final int tokenCount;
   final int streak;
   final String? lastChallengeText;
-  final Timestamp? lastChallenge;
+  final DateTime? lastChallenge;
   final int individualPoints;
   final Map<String, dynamic> streakMilestones;
 
@@ -23,18 +21,18 @@ class UserModel {
     required this.streakMilestones,
   });
 
-  factory UserModel.fromFirestore(DocumentSnapshot doc) {
-    final data = doc.data() as Map<String, dynamic>? ?? {};
+  factory UserModel.fromMap(Map<String, dynamic> data, String uid) {
     return UserModel(
-      uid: doc.id,
-      religion: data['religion'],
-      organizationId: data['organizationId'],
-      tokenCount: data['tokenCount'] ?? 0,
-      streak: data['streak'] ?? 0,
-      lastChallengeText: data['lastChallengeText'],
-      lastChallenge: data['lastChallenge'],
-      individualPoints: data['individualPoints'] ?? 0,
-      streakMilestones: Map<String, dynamic>.from(data['streakMilestones'] ?? {}),
+      uid: uid,
+      religion: data['religion'] as String?,
+      organizationId: data['organizationId'] as String?,
+      tokenCount: (data['tokenCount'] as int?) ?? 0,
+      streak: (data['streak'] as int?) ?? 0,
+      lastChallengeText: data['lastChallengeText'] as String?,
+      lastChallenge: data['lastChallenge'] as DateTime?,
+      individualPoints: (data['individualPoints'] as int?) ?? 0,
+      streakMilestones:
+          Map<String, dynamic>.from(data['streakMilestones'] as Map? ?? {}),
     );
   }
 

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../state/auth_providers.dart';
 import 'signup_screen.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
@@ -84,22 +83,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       if (mounted) {
         context.go('/home');
       }
-    } on FirebaseAuthException catch (e) {
+    } catch (e) {
       setState(() {
-        _errorMessage = e.message ?? 'An unknown error occurred.';
+        _errorMessage = e.toString();
       });
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(_errorMessage)),
-        );
-      }
-    } catch (e) {
-      setState(() {
-        _errorMessage = 'An unexpected error occurred.';
-      });
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('An unexpected error occurred.')),
         );
       }
     } finally {

--- a/lib/services/firebase_config.dart
+++ b/lib/services/firebase_config.dart
@@ -1,0 +1,2 @@
+const firebaseApiKey = String.fromEnvironment('FIREBASE_API_KEY');
+const firebaseProjectId = String.fromEnvironment('FIREBASE_PROJECT_ID', defaultValue: 'wwjd-app');

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -1,45 +1,148 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'firebase_config.dart';
+import 'auth_service.dart';
 import '../models/user_model.dart';
 
 class FirestoreService {
-  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  final AuthService _auth;
+  FirestoreService(this._auth);
 
-  Future<UserModel?> getUser(String uid) async {
-    final doc = await _db.collection('users').doc(uid).get();
-    if (doc.exists) {
-      return UserModel.fromFirestore(doc);
+  String get _baseUrl =>
+      'https://firestore.googleapis.com/v1/projects/$firebaseProjectId/databases/(default)/documents';
+
+  Map<String, String> _headers(String? idToken) => {
+        'Content-Type': 'application/json',
+        if (idToken != null) 'Authorization': 'Bearer $idToken',
+      };
+
+  Map<String, dynamic> _wrapFields(Map<String, dynamic> data) {
+    return {
+      'fields': data.map((k, v) => MapEntry(k, _encodeValue(v)))
+    };
+  }
+
+  Map<String, dynamic> _encodeValue(dynamic value) {
+    if (value is int) return {'integerValue': value.toString()};
+    if (value is double) return {'doubleValue': value};
+    if (value is bool) return {'booleanValue': value};
+    if (value is DateTime) return {'timestampValue': value.toIso8601String()};
+    if (value is Map<String, dynamic>) {
+      return {
+        'mapValue': {'fields': value.map((k, v) => MapEntry(k, _encodeValue(v)))}
+      };
+    }
+    return {'stringValue': value.toString()};
+  }
+
+  dynamic _decodeValue(Map<String, dynamic> value) {
+    if (value.containsKey('stringValue')) return value['stringValue'];
+    if (value.containsKey('integerValue'))
+      return int.tryParse(value['integerValue'] as String) ?? 0;
+    if (value.containsKey('doubleValue')) return value['doubleValue'];
+    if (value.containsKey('booleanValue')) return value['booleanValue'];
+    if (value.containsKey('timestampValue'))
+      return DateTime.parse(value['timestampValue']);
+    if (value.containsKey('mapValue')) {
+      final fields = value['mapValue']['fields'] as Map<String, dynamic>? ?? {};
+      return fields.map((k, v) => MapEntry(k, _decodeValue(v)));
     }
     return null;
   }
 
-  Stream<UserModel?> watchUser(String uid) {
-    return _db.collection('users').doc(uid).snapshots().map((doc) {
-      if (doc.exists) {
-        return UserModel.fromFirestore(doc);
-      }
-      return null;
-    });
+  Map<String, dynamic> _decodeFields(Map<String, dynamic> fields) {
+    return fields.map((k, v) => MapEntry(k, _decodeValue(v)));
   }
 
-  Future<void> createUser(String uid, Map<String, dynamic> data) {
-    return _db.collection('users').doc(uid).set(data);
+  Future<Map<String, dynamic>?> getDocument(String path) async {
+    final idToken = await _auth.getIdToken();
+    final res = await http.get(
+      Uri.parse('$_baseUrl/$path'),
+      headers: _headers(idToken),
+    );
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final fields = data['fields'] as Map<String, dynamic>?;
+      if (fields == null) return null;
+      return _decodeFields(fields);
+    }
+    return null;
   }
 
-  Future<void> updateUser(String uid, Map<String, dynamic> data) {
-    return _db.collection('users').doc(uid).update(data);
+  Future<void> setDocument(String path, Map<String, dynamic> data) async {
+    final idToken = await _auth.getIdToken();
+    await http.patch(
+      Uri.parse('$_baseUrl/$path'),
+      headers: _headers(idToken),
+      body: jsonEncode(_wrapFields(data)),
+    );
   }
 
-  Future<void> incrementReligionPoints(String religionId, int points) {
-    return _db
-        .collection('religions')
-        .doc(religionId)
-        .update({'totalPoints': FieldValue.increment(points)});
+  Future<UserModel?> getUser(String uid) async {
+    final idToken = await _auth.getIdToken();
+    final res = await http.get(
+      Uri.parse('$_baseUrl/users/$uid'),
+      headers: _headers(idToken),
+    );
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final fields = data['fields'] as Map<String, dynamic>?;
+      if (fields == null) return null;
+      return UserModel.fromMap(_decodeFields(fields), uid);
+    }
+    return null;
   }
 
-  Future<void> incrementOrganizationPoints(String organizationId, int points) {
-    return _db
-        .collection('organizations')
-        .doc(organizationId)
-        .update({'totalPoints': FieldValue.increment(points)});
+  Stream<UserModel?> watchUser(String uid) async* {
+    while (true) {
+      yield await getUser(uid);
+      await Future.delayed(const Duration(seconds: 5));
+    }
+  }
+
+  Future<void> createUser(String uid, Map<String, dynamic> data) async {
+    final idToken = await _auth.getIdToken();
+    await http.patch(
+      Uri.parse('$_baseUrl/users/$uid'),
+      headers: _headers(idToken),
+      body: jsonEncode(_wrapFields(data)),
+    );
+  }
+
+  Future<void> updateUser(String uid, Map<String, dynamic> data) async {
+    await createUser(uid, data);
+  }
+
+  Future<void> _increment(String collection, String docId, int points) async {
+    final fields = await getDocument('$collection/$docId');
+    final current = fields?['totalPoints'] as int? ?? 0;
+    await updateDoc(collection, docId, {'totalPoints': current + points});
+  }
+
+  Future<void> updateDoc(
+      String collection, String docId, Map<String, dynamic> data) async {
+    final idToken = await _auth.getIdToken();
+    await http.patch(
+      Uri.parse('$_baseUrl/$collection/$docId'),
+      headers: _headers(idToken),
+      body: jsonEncode(_wrapFields(data)),
+    );
+  }
+
+  Future<void> updateDocumentPath(String path, Map<String, dynamic> data) async {
+    final idToken = await _auth.getIdToken();
+    await http.patch(
+      Uri.parse('$_baseUrl/$path'),
+      headers: _headers(idToken),
+      body: jsonEncode(_wrapFields(data)),
+    );
+  }
+
+  Future<void> incrementReligionPoints(String religionId, int points) async {
+    await _increment('religions', religionId, points);
+  }
+
+  Future<void> incrementOrganizationPoints(String organizationId, int points) async {
+    await _increment('organizations', organizationId, points);
   }
 }

--- a/lib/services/functions_service.dart
+++ b/lib/services/functions_service.dart
@@ -1,28 +1,29 @@
-import 'package:cloud_functions/cloud_functions.dart';
+import 'http_service.dart';
 
 class FunctionsService {
-  final FirebaseFunctions _functions = FirebaseFunctions.instance;
+  final HttpService _http;
+  FunctionsService(this._http);
 
-  Future<String> askGemini({required List<Map<String, String>> history, required String religion}) async {
-    final result = await _functions.httpsCallable('askGeminiV2').call({
+  Future<String> askGemini({required List<Map<String, String>> history, required String religion, String? idToken}) async {
+    final data = await _http.post('askGeminiV2', {
       'history': history,
       'religion': religion,
-    });
-    return result.data['text'] as String? ?? '';
+    }, idToken: idToken);
+    return data['text'] as String? ?? '';
   }
 
-  Future<String> getDailyChallenge({required String religion}) async {
-    final result = await _functions.httpsCallable('getDailyChallenge').call({
+  Future<String> getDailyChallenge({required String religion, String? idToken}) async {
+    final data = await _http.post('getDailyChallenge', {
       'religion': religion,
-    });
-    return result.data['text'] as String? ?? '';
+    }, idToken: idToken);
+    return data['text'] as String? ?? '';
   }
 
-  Future<String> getMilestoneBlessing({required String religion, required int streak}) async {
-    final result = await _functions.httpsCallable('getMilestoneBlessing').call({
+  Future<String> getMilestoneBlessing({required String religion, required int streak, String? idToken}) async {
+    final data = await _http.post('getMilestoneBlessing', {
       'religion': religion,
       'streak': streak,
-    });
-    return result.data['text'] as String? ?? '';
+    }, idToken: idToken);
+    return data['text'] as String? ?? '';
   }
 }

--- a/lib/services/http_service.dart
+++ b/lib/services/http_service.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
-import 'package:firebase_auth/firebase_auth.dart';
 
 /// Exception thrown when a HTTP call fails.
 class HttpServiceException implements Exception {
@@ -35,7 +34,6 @@ class HttpService {
     String? idToken,
     Map<String, String>? headers,
   }) async {
-    idToken ??= await FirebaseAuth.instance.currentUser?.getIdToken();
 
     final requestHeaders = <String, String>{
       'Content-Type': 'application/json',

--- a/lib/state/auth_providers.dart
+++ b/lib/state/auth_providers.dart
@@ -1,19 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import '../services/auth_service.dart';
-
-final firebaseAuthProvider = Provider<FirebaseAuth>((ref) {
-  return FirebaseAuth.instance;
-});
-
-final authStateChangesProvider = StreamProvider<User?>((ref) {
-  return ref.watch(firebaseAuthProvider).authStateChanges();
-});
-
-final currentUserProvider = Provider<User?>((ref) {
-  return ref.watch(firebaseAuthProvider).currentUser;
-});
 
 final authServiceProvider = Provider<AuthService>((ref) {
   return AuthService();
+});
+
+final authStateChangesProvider = StreamProvider<AuthUser?>((ref) {
+  return ref.watch(authServiceProvider).authStateChanges;
+});
+
+final currentUserProvider = Provider<AuthUser?>((ref) {
+  return ref.watch(authServiceProvider).currentUser;
 });

--- a/lib/state/challenge_provider.dart
+++ b/lib/state/challenge_provider.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/daily_challenge.dart';
 import '../services/user_service.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'user_provider.dart';
 
 class ChallengeProvider with ChangeNotifier {

--- a/lib/state/confessional_provider.dart
+++ b/lib/state/confessional_provider.dart
@@ -41,7 +41,7 @@ class ConfessionalNotifier extends StateNotifier<ConfessionalState> {
 
   Future<void> sendMessage(String text) async {
     if (text.trim().isEmpty) return;
-    final auth = ref.read(firebaseAuthProvider);
+    final auth = ref.read(authServiceProvider);
     final user = auth.currentUser;
     if (user == null) return;
     final firestore = ref.read(firestoreServiceProvider);
@@ -62,7 +62,7 @@ class ConfessionalNotifier extends StateNotifier<ConfessionalState> {
       final conversation = newMessages
           .map((m) => "${m['role']}: ${m['text']}")
           .join('\n');
-      final idToken = await auth.currentUser?.getIdToken();
+      final idToken = await auth.getIdToken();
       final httpService = ref.read(httpServiceProvider);
       final data = await httpService.post('askGeminiV2', {
         'conversation': conversation,

--- a/lib/state/firestore_providers.dart
+++ b/lib/state/firestore_providers.dart
@@ -4,13 +4,14 @@ import 'auth_providers.dart';
 import '../models/user_model.dart';
 
 final firestoreServiceProvider = Provider<FirestoreService>((ref) {
-  return FirestoreService();
+  final auth = ref.watch(authServiceProvider);
+  return FirestoreService(auth);
 });
 
 final userDataProvider = StreamProvider<UserModel?>((ref) {
-  final auth = ref.watch(firebaseAuthProvider);
+  final auth = ref.watch(authServiceProvider);
   final firestore = ref.watch(firestoreServiceProvider);
-  return auth.authStateChanges().asyncExpand((user) {
+  return auth.authStateChanges.asyncExpand((user) {
     if (user == null) return Stream.value(null);
     return firestore.watchUser(user.uid);
   });

--- a/lib/state/functions_provider.dart
+++ b/lib/state/functions_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/functions_service.dart';
+import 'http_provider.dart';
 
 final functionsServiceProvider = Provider<FunctionsService>((ref) {
-  return FunctionsService();
+  final httpService = ref.watch(httpServiceProvider);
+  return FunctionsService(httpService);
 });

--- a/lib/state/religion_ai_provider.dart
+++ b/lib/state/religion_ai_provider.dart
@@ -43,7 +43,7 @@ class ReligionAINotifier extends StateNotifier<ReligionAIState> {
   Future<void> askQuestion(String question) async {
     final trimmed = question.trim();
     if (trimmed.isEmpty) return;
-    final auth = ref.read(firebaseAuthProvider);
+    final auth = ref.read(authServiceProvider);
     final user = auth.currentUser;
     if (user == null) return;
     final userData = await ref.read(firestoreServiceProvider).getUser(user.uid);
@@ -52,7 +52,7 @@ class ReligionAINotifier extends StateNotifier<ReligionAIState> {
     state = state.copyWith(loading: true, error: null, question: trimmed);
     try {
       final httpService = ref.read(httpServiceProvider);
-      final idToken = await auth.currentUser?.getIdToken();
+      final idToken = await auth.getIdToken();
       final data = await httpService.post('askGeminiV2', {
         'history': [
           {'role': 'user', 'text': trimmed}

--- a/lib/state/trivia_provider.dart
+++ b/lib/state/trivia_provider.dart
@@ -43,7 +43,7 @@ class TriviaNotifier extends StateNotifier<TriviaState> {
     state = state.copyWith(loading: true, error: null, resultText: null);
     try {
       final httpService = ref.read(httpServiceProvider);
-      final idToken = await ref.read(firebaseAuthProvider).currentUser?.getIdToken();
+      final idToken = await ref.read(authServiceProvider).getIdToken();
       final data = await httpService.post('getTriviaQuestion', {}, idToken: idToken);
       state = state.copyWith(
         story: data['story'] as String?,
@@ -58,7 +58,7 @@ class TriviaNotifier extends StateNotifier<TriviaState> {
   }
 
   Future<void> submitGuess(String religionGuess, String storyGuess) async {
-    final auth = ref.read(firebaseAuthProvider);
+    final auth = ref.read(authServiceProvider);
     final user = auth.currentUser;
     if (user == null || state.storyId == null) return;
     final firestore = ref.read(firestoreServiceProvider);
@@ -68,7 +68,7 @@ class TriviaNotifier extends StateNotifier<TriviaState> {
     state = state.copyWith(loading: true, error: null);
     try {
       final httpService = ref.read(httpServiceProvider);
-      final idToken = await auth.currentUser?.getIdToken();
+      final idToken = await auth.getIdToken();
       final data = await httpService.post('validateTriviaAnswer', {
         'id': state.storyId,
         'religionGuess': religionGuess,

--- a/lib/state/user_provider.dart
+++ b/lib/state/user_provider.dart
@@ -1,6 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/user_service.dart';
+import 'auth_providers.dart';
+import 'firestore_providers.dart';
+import 'functions_provider.dart';
 
 final userServiceProvider = ChangeNotifierProvider<UserService>((ref) {
-  return UserService();
+  final auth = ref.watch(authServiceProvider);
+  final firestore = ref.watch(firestoreServiceProvider);
+  final functions = ref.watch(functionsServiceProvider);
+  return UserService(auth, firestore, functions);
 });


### PR DESCRIPTION
## Summary
- remove Firebase initialization and SDK imports
- add simple REST-based auth and Firestore clients
- replace previous FlutterFire usage with HTTP requests
- adjust providers and screens for new services

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a4dc049c8330b4fe4af3b97b473d