### PR TITLE
Fix provider usage and cleanup imports

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -84,7 +84,7 @@ void main() async {
 }
 
 class MyApp extends ConsumerWidget { // Changed to ConsumerWidget to access provider
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) { // Added WidgetRef

--- a/lib/screens/auth/signup_screen.dart
+++ b/lib/screens/auth/signup_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../state/auth_providers.dart';
 import '../../state/firestore_providers.dart';
-import 'login_screen.dart';
 import 'package:go_router/go_router.dart';
 
 class SignupScreen extends ConsumerStatefulWidget {

--- a/lib/screens/challenge_screen.dart
+++ b/lib/screens/challenge_screen.dart
@@ -37,14 +37,13 @@ class ChallengeScreen extends ConsumerWidget {
           }
 
           if (state.error != null) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text(state.error!)),
-              );
-              ref.read(dailyChallengeProvider.notifier)
-                  .state = state.copyWith(error: null);
-            });
-          }
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(state.error!)),
+                );
+                ref.read(dailyChallengeProvider.notifier).clearError();
+              });
+            }
 
           return Padding(
             padding: const EdgeInsets.all(16.0),

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -23,7 +23,7 @@ class ProfileScreen extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('Email: ${authService.getCurrentUser()?.email ?? 'N/A'}',
+                Text('Email: ${authService.currentUser?.email ?? 'N/A'}',
                     style: const TextStyle(fontSize: 18)),
                 const SizedBox(height: 12),
                 Text('Religion: ${user.religion ?? 'None'}'),

--- a/lib/state/daily_challenge_provider.dart
+++ b/lib/state/daily_challenge_provider.dart
@@ -121,6 +121,10 @@ class DailyChallengeNotifier extends StateNotifier<DailyChallengeState> {
 
     state = state.copyWith();
   }
+
+  void clearError() {
+    state = state.copyWith(error: null);
+  }
 }
 
 final dailyChallengeProvider =


### PR DESCRIPTION
## Summary
- show user email using `currentUser`
- clean imports on sign up screen
- use `clearError` to update challenge provider state
- add `clearError` method on the provider
- convert `key` to super parameter in `MyApp`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6856a7c57ba48330a821b45c5d23b710