### PR TITLE
Implement Gemini REST service and improve providers

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'dart:async';
+import 'utils/async_extensions.dart';
 
 import 'screens/auth/login_screen.dart';
 import 'screens/home_screen.dart';
@@ -65,7 +66,7 @@ final routerProvider = Provider<GoRouter>((ref) {
     ],
     redirect: (context, state) {
       final loggedIn = ref.read(currentUserProvider) != null;
-      final loggingIn = state.location == '/login';
+      final loggingIn = state.uri.toString() == '/login';
       if (!loggedIn) return loggingIn ? null : '/login';
       if (loggingIn) return '/home';
       return null;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../state/firestore_providers.dart';
 import '../models/user_model.dart';
+import '../state/daily_challenge_status_provider.dart';
 import 'journal_screen.dart';
 import 'challenge_screen.dart';
 import 'profile_screen.dart';
@@ -31,6 +32,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           if (user == null) {
             return const Center(child: Text('User data not found.'));
           }
+          final challengeAsync = ref.watch(dailyChallengeStatusProvider);
 
           return Padding(
             padding: const EdgeInsets.all(16.0),
@@ -42,8 +44,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 Text('Tokens: ${user.tokenCount}', style: Theme.of(context).textTheme.titleLarge),
                 const SizedBox(height: 16),
                 Text('Daily Challenge Status:', style: Theme.of(context).textTheme.titleLarge),
-                // TODO: Display actual challenge status based on user.dailyChallengeStatus
-                Text('Challenge status goes here.'),
+                challengeAsync.when(
+                  data: (challenge) {
+                    if (challenge == null) return const Text('No challenge.');
+                    if (challenge.completed) return const Text('Completed');
+                    if (challenge.skipped) return const Text('Skipped');
+                    return const Text('Pending');
+                  },
+                  loading: () => const Text('Loading...'),
+                  error: (e, _) => const Text('Error'),
+                ),
                 const SizedBox(height: 16),
                 ElevatedButton(
                   onPressed: () {

--- a/lib/state/challenge_provider.dart
+++ b/lib/state/challenge_provider.dart
@@ -40,7 +40,7 @@ class ChallengeProvider with ChangeNotifier {
   Future<void> completeChallenge() async {
     if (_dailyChallenge != null && !_dailyChallenge!.completed && !_dailyChallenge!.skipped) {
       await _userService.completeDailyChallenge();
-      // TODO: Implement token awarding logic and update _tokenCount
+      _tokenCount += 3; // award tokens locally
       await fetchDailyChallengeForToday(); // Refresh challenge status
       await _updateUserDataFromService(); // Refresh token count
     }

--- a/lib/state/daily_challenge_status_provider.dart
+++ b/lib/state/daily_challenge_status_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/daily_challenge.dart';
+import '../services/firestore_service.dart';
+import 'auth_providers.dart';
+import 'firestore_providers.dart';
+
+final dailyChallengeStatusProvider = FutureProvider<DailyChallenge?>((ref) async {
+  final auth = ref.watch(authServiceProvider);
+  final firestore = ref.watch(firestoreServiceProvider);
+  final user = auth.currentUser;
+  if (user == null) return null;
+  final now = DateTime.now();
+  final todayStr =
+      '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+  final data = await firestore.getDocument('users/${user.uid}/dailyChallenges/$todayStr');
+  return data != null ? DailyChallenge.fromMap(data) : null;
+});

--- a/lib/state/gemini_provider.dart
+++ b/lib/state/gemini_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/gemini_service.dart';
+
+final geminiServiceProvider = Provider<GeminiService>((ref) {
+  const key = String.fromEnvironment('GEMINI_API_KEY');
+  return GeminiService(apiKey: key);
+});

--- a/lib/state/religion_ai_provider.dart
+++ b/lib/state/religion_ai_provider.dart
@@ -1,8 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'auth_providers.dart';
 import 'firestore_providers.dart';
-import '../state/http_provider.dart';
-import '../services/http_service.dart';
+import 'gemini_provider.dart';
 
 class ReligionAIState {
   final String question;
@@ -51,21 +50,18 @@ class ReligionAINotifier extends StateNotifier<ReligionAIState> {
 
     state = state.copyWith(loading: true, error: null, question: trimmed);
     try {
-      final httpService = ref.read(httpServiceProvider);
-      final idToken = await auth.getIdToken();
-      final data = await httpService.post('askGeminiV2', {
-        'history': [
+      final gemini = ref.read(geminiServiceProvider);
+      final text = await gemini.chat(
+        [
           {'role': 'user', 'text': trimmed}
         ],
-        'religion': userData.religion ?? 'spiritual',
-      }, idToken: idToken);
+        userData.religion ?? 'spiritual',
+      );
 
       state = state.copyWith(
-        response: data['text'] as String? ?? '',
+        response: text,
         loading: false,
       );
-    } on HttpServiceException catch (e) {
-      state = state.copyWith(error: e.message, loading: false);
     } catch (e) {
       state = state.copyWith(error: e.toString(), loading: false);
     }

--- a/lib/utils/async_extensions.dart
+++ b/lib/utils/async_extensions.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+extension AsyncValueStreamX<T> on AsyncValue<T> {
+  /// Convert an [AsyncValue] into a single-subscription [Stream].
+  Stream<T?> asStream() {
+    return when<Stream<T?>>(
+      data: (data) => Stream<T>.value(data),
+      error: (err, st) => Stream<T>.error(err, st),
+      loading: () => const Stream.empty(),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   flutter_riverpod: ^2.3.6
   go_router: ^7.1.1
   http: ^0.13.6
+  logging: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `logging` dependency
- implement Gemini REST client with logging
- expose Gemini via new provider
- connect daily challenge, confessional, and religion AI flows to Gemini
- show challenge status on `HomeScreen`
- extend `AsyncValue` with `asStream`
- fix GoRouter redirect state usage and update challenge provider logic

## Testing
- `dart format lib` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa6d892083309bd34662bee5915e