### PR TITLE
Fix router state, remove unused imports

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,7 +66,7 @@ final routerProvider = Provider<GoRouter>((ref) {
     ],
     redirect: (context, state) {
       final loggedIn = ref.read(currentUserProvider) != null;
-      final loggingIn = state.uri.toString() == '/login';
+      final loggingIn = state.location == '/login';
       if (!loggedIn) return loggingIn ? null : '/login';
       if (loggingIn) return '/home';
       return null;

--- a/lib/screens/auth/onboarding_screen.dart
+++ b/lib/screens/auth/onboarding_screen.dart
@@ -5,7 +5,7 @@ class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({super.key});
 
   @override
-  _OnboardingScreenState createState() => _OnboardingScreenState();
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
 }
 
 class _OnboardingScreenState extends State<OnboardingScreen> {

--- a/lib/screens/confessional_screen.dart
+++ b/lib/screens/confessional_screen.dart
@@ -15,8 +15,7 @@ class ConfessionalScreen extends ConsumerWidget {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text(state.error!)));
-        ref.read(confessionalProvider.notifier).state =
-            state.copyWith(error: null);
+        ref.read(confessionalProvider.notifier).clearError();
       });
     }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,10 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../state/firestore_providers.dart';
 import '../models/user_model.dart';
 import '../state/daily_challenge_status_provider.dart';
-import 'journal_screen.dart';
-import 'challenge_screen.dart';
-import 'profile_screen.dart';
-import 'quote_screen.dart';
 import 'religion_ai_screen.dart'; // Import the ReligionAIScreen
 
 class HomeScreen extends ConsumerStatefulWidget {

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -23,10 +23,18 @@ class FirestoreService {
   }
 
   Map<String, dynamic> _encodeValue(dynamic value) {
-    if (value is int) return {'integerValue': value.toString()};
-    if (value is double) return {'doubleValue': value};
-    if (value is bool) return {'booleanValue': value};
-    if (value is DateTime) return {'timestampValue': value.toIso8601String()};
+    if (value is int) {
+      return {'integerValue': value.toString()};
+    }
+    if (value is double) {
+      return {'doubleValue': value};
+    }
+    if (value is bool) {
+      return {'booleanValue': value};
+    }
+    if (value is DateTime) {
+      return {'timestampValue': value.toIso8601String()};
+    }
     if (value is Map<String, dynamic>) {
       return {
         'mapValue': {'fields': value.map((k, v) => MapEntry(k, _encodeValue(v)))}
@@ -36,13 +44,21 @@ class FirestoreService {
   }
 
   dynamic _decodeValue(Map<String, dynamic> value) {
-    if (value.containsKey('stringValue')) return value['stringValue'];
-    if (value.containsKey('integerValue'))
+    if (value.containsKey('stringValue')) {
+      return value['stringValue'];
+    }
+    if (value.containsKey('integerValue')) {
       return int.tryParse(value['integerValue'] as String) ?? 0;
-    if (value.containsKey('doubleValue')) return value['doubleValue'];
-    if (value.containsKey('booleanValue')) return value['booleanValue'];
-    if (value.containsKey('timestampValue'))
+    }
+    if (value.containsKey('doubleValue')) {
+      return value['doubleValue'];
+    }
+    if (value.containsKey('booleanValue')) {
+      return value['booleanValue'];
+    }
+    if (value.containsKey('timestampValue')) {
       return DateTime.parse(value['timestampValue']);
+    }
     if (value.containsKey('mapValue')) {
       final fields = value['mapValue']['fields'] as Map<String, dynamic>? ?? {};
       return fields.map((k, v) => MapEntry(k, _decodeValue(v)));
@@ -63,7 +79,9 @@ class FirestoreService {
     if (res.statusCode == 200) {
       final data = jsonDecode(res.body) as Map<String, dynamic>;
       final fields = data['fields'] as Map<String, dynamic>?;
-      if (fields == null) return null;
+      if (fields == null) {
+        return null;
+      }
       return _decodeFields(fields);
     }
     return null;
@@ -87,7 +105,9 @@ class FirestoreService {
     if (res.statusCode == 200) {
       final data = jsonDecode(res.body) as Map<String, dynamic>;
       final fields = data['fields'] as Map<String, dynamic>?;
-      if (fields == null) return null;
+      if (fields == null) {
+        return null;
+      }
       return UserModel.fromMap(_decodeFields(fields), uid);
     }
     return null;

--- a/lib/state/confessional_provider.dart
+++ b/lib/state/confessional_provider.dart
@@ -36,6 +36,10 @@ class ConfessionalNotifier extends StateNotifier<ConfessionalState> {
 
   final Ref ref;
 
+  void clearError() {
+    state = state.copyWith(error: null);
+  }
+
   Future<void> sendMessage(String text) async {
     if (text.trim().isEmpty) return;
     final auth = ref.read(authServiceProvider);

--- a/lib/state/daily_challenge_status_provider.dart
+++ b/lib/state/daily_challenge_status_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/daily_challenge.dart';
-import '../services/firestore_service.dart';
 import 'auth_providers.dart';
 import 'firestore_providers.dart';
 


### PR DESCRIPTION
## Summary
- update `redirect` logic to use `state.location`
- provide `clearError` method in `ConfessionalNotifier`
- use `clearError()` in ConfessionalScreen
- clean up unused imports on HomeScreen and daily challenge provider
- fix private state type in onboarding screen
- add braces for if-statements in FirestoreService

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856b104696c83309fc69db82aab17fa